### PR TITLE
Legg på arbeidsKategoriKode på utbetalingene fra infotrygd

### DIFF
--- a/sykepengeperioder/src/main/kotlin/no/nav/helse/sparkel/sykepengeperioder/infotrygd/Utbetalingsperioder.kt
+++ b/sykepengeperioder/src/main/kotlin/no/nav/helse/sparkel/sykepengeperioder/infotrygd/Utbetalingsperioder.kt
@@ -4,10 +4,11 @@ import com.fasterxml.jackson.databind.JsonNode
 import java.time.LocalDate
 
 class Utbetalingsperioder(jsonNode: JsonNode) {
-    val perioder = jsonNode["utbetalingList"].map { Utbetalingsperiode(it) }
+    val arbeidsKategoriKode = jsonNode["arbeidsKategoriKode"].asText()
+    val perioder = jsonNode["utbetalingList"].map { Utbetalingsperiode(it, arbeidsKategoriKode) }
 }
 
-data class Utbetalingsperiode(private val jsonNode: JsonNode) {
+data class Utbetalingsperiode(private val jsonNode: JsonNode, val arbeidsKategoriKode: String) {
     val fom: LocalDate? = jsonNode["fom"]?.takeUnless { it.isNull }?.textValue()?.let { LocalDate.parse(it) }
     val tom: LocalDate? = jsonNode["tom"]?.takeUnless { it.isNull }?.textValue()?.let { LocalDate.parse(it) }
     val dagsats: Double = jsonNode["dagsats"].doubleValue()

--- a/sykepengeperioder/src/test/kotlin/no/nav/helse/sparkel/sykepengeperioder/UtbetalingsperiodeløserTest.kt
+++ b/sykepengeperioder/src/test/kotlin/no/nav/helse/sparkel/sykepengeperioder/UtbetalingsperiodeløserTest.kt
@@ -113,7 +113,29 @@ internal class UtbetalingsperiodeløserTest {
             grad = "100",
             dagsats = 870.0,
             typetekst = "ArbRef",
-            organisasjonsnummer = orgnummer
+            organisasjonsnummer = orgnummer,
+            arbeidsKategoriKode = "01"
+        )
+    }
+
+    @Test
+    fun `mapper også ut arbeidsKategoriKode`() {
+        testBehov(enkeltBehov())
+
+        val løsninger = sendtMelding.løsning()
+        assertEquals(1, løsninger.size)
+
+        val periode = løsninger.first()
+
+        assertInfotrygdperiode(
+            periode = periode,
+            fom = 19.januar,
+            tom = 23.januar,
+            grad = "100",
+            dagsats = 870.0,
+            typetekst = "ArbRef",
+            organisasjonsnummer = orgnummer,
+            arbeidsKategoriKode = "01"
         )
     }
 
@@ -128,6 +150,7 @@ internal class UtbetalingsperiodeløserTest {
         val dagsats = json["dagsats"].asDouble()
         val typetekst = json["typetekst"].asText()
         val organisasjonsnummer = json["organisasjonsnummer"].asText()
+        val arbeidsKategoriKode = json["arbeidsKategoriKode"].asText()
 
         private companion object {
             fun JsonNode.asLocalDate() = LocalDate.parse(this.asText())
@@ -145,7 +168,8 @@ internal class UtbetalingsperiodeløserTest {
         tom: LocalDate, grad: String,
         dagsats: Double,
         typetekst: String,
-        organisasjonsnummer: String
+        organisasjonsnummer: String,
+        arbeidsKategoriKode: String,
     ) {
         assertEquals(fom, periode.fom)
         assertEquals(tom, periode.tom)
@@ -153,6 +177,7 @@ internal class UtbetalingsperiodeløserTest {
         assertEquals(dagsats, periode.dagsats)
         assertEquals(typetekst, periode.typetekst)
         assertEquals(organisasjonsnummer, periode.organisasjonsnummer)
+        assertEquals(arbeidsKategoriKode, periode.arbeidsKategoriKode)
     }
 
     private fun behovMedFlereBehovsnøkler() =

--- a/sykepengeperioder/src/test/kotlin/no/nav/helse/sparkel/sykepengeperioder/infotrygd/UtbetalingsperioderTest.kt
+++ b/sykepengeperioder/src/test/kotlin/no/nav/helse/sparkel/sykepengeperioder/infotrygd/UtbetalingsperioderTest.kt
@@ -54,6 +54,7 @@ internal class UtbetalingsperioderTest {
         assertEquals(765.0, enIkkeTomUtbetalingsperiode.dagsats)
         assertEquals("ArbRef", enIkkeTomUtbetalingsperiode.typetekst)
         assertEquals("88888888", enIkkeTomUtbetalingsperiode.organisasjonsnummer)
+        assertEquals("01", enIkkeTomUtbetalingsperiode.arbeidsKategoriKode)
     }
 
     private val objectMapper = jacksonObjectMapper()


### PR DESCRIPTION
Dette feltet kan vi bruke til å filtrere saker som skal kastes ut pga redusert utbetaling grunnet inaktivitet o.l

_Antar_ at dette feltet alltid er satt. Om det ikke er det vil det eksplodere, men da er det bare å myke det opp tenker jeg..