### PR TITLE
forbereder config til aiven-prod

### DIFF
--- a/config/aareg/dev-fss.yml
+++ b/config/aareg/dev-fss.yml
@@ -3,10 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/dev/srvsparkelaareg
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-aareg-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: STS_BASE_SOAP_URL
   value: https://sts-q1.preprod.local/SecurityTokenServiceProvider/
 - name: KODEVERK_BASE_URL

--- a/config/aareg/prod-fss.yml
+++ b/config/aareg/prod-fss.yml
@@ -3,14 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkelaareg
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-aareg-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: STS_BASE_SOAP_URL
   value: https://sts.adeo.no/SecurityTokenServiceProvider/
 - name: KODEVERK_BASE_URL

--- a/config/arena/dev-fss.yml
+++ b/config/arena/dev-fss.yml
@@ -3,10 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/dev/srvsparkelarena
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-arena-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: STS_URL
   value: https://sts-q2.preprod.local/SecurityTokenServiceProvider/
 - name: YTELSESKONTRAKT_BASE_URL

--- a/config/arena/prod-fss.yml
+++ b/config/arena/prod-fss.yml
@@ -3,14 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkelarena
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-arena-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: STS_URL
   value: https://sts.adeo.no/SecurityTokenServiceProvider/
 - name: YTELSESKONTRAKT_BASE_URL

--- a/config/dkif/dev-fss.yml
+++ b/config/dkif/dev-fss.yml
@@ -3,10 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/dev/srvsparkeldkif
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-dkif-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: STS_BASE_URL
   value: http://security-token-service.default.svc.nais.local
 - name: DKIF_URL

--- a/config/dkif/prod-fss.yml
+++ b/config/dkif/prod-fss.yml
@@ -3,14 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkeldkif
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-dkif-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: STS_BASE_URL
   value: http://security-token-service.default.svc.nais.local
 - name: DKIF_URL

--- a/config/gosys/dev-fss.yml
+++ b/config/gosys/dev-fss.yml
@@ -3,10 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/dev/srvsparkelgosys
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-gosys-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: STS_BASE_URL
   value: http://security-token-service.default.svc.nais.local
 - name: OPPGAVE_URL

--- a/config/gosys/prod-fss.yml
+++ b/config/gosys/prod-fss.yml
@@ -3,14 +3,6 @@ mountPaths:
   - mountPath: /var/run/secrets/nais.io/service_user
     kvPath: /serviceuser/data/prod/srvsparkelgosys
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-gosys-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: STS_BASE_URL
   value: http://security-token-service.default.svc.nais.local
 - name: OPPGAVE_URL

--- a/config/inntekt/dev-fss.yml
+++ b/config/inntekt/dev-fss.yml
@@ -3,9 +3,5 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/dev/srvsparkelinntekt
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-inntekt-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: INNTEKTSKOMPONENT_BASE_URL
   value: https://app-q1.adeo.no/inntektskomponenten-ws/rs

--- a/config/inntekt/prod-fss.yml
+++ b/config/inntekt/prod-fss.yml
@@ -3,13 +3,5 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkelinntekt
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-inntekt-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: INNTEKTSKOMPONENT_BASE_URL
   value: https://app.adeo.no/inntektskomponenten-ws/rs

--- a/config/institusjonsopphold/dev-fss.yml
+++ b/config/institusjonsopphold/dev-fss.yml
@@ -3,10 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/dev/srvsparkelinst
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-institusjonsopphold-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: STS_BASE_URL
   value: http://security-token-service.default.svc.nais.local
 - name: INSTITUSJONSOPPHOLD_URL

--- a/config/institusjonsopphold/prod-fss.yml
+++ b/config/institusjonsopphold/prod-fss.yml
@@ -3,14 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkelinst
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-institusjonsopphold-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: STS_BASE_URL
   value: http://security-token-service.default.svc.nais.local
 - name: INSTITUSJONSOPPHOLD_URL

--- a/config/medlemskap/dev-fss.yml
+++ b/config/medlemskap/dev-fss.yml
@@ -3,10 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/azuread
   kvPath: /azuread/data/dev/creds/sparkel-medlemskap
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-medlemskap-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: AZURE_TENANT_ID
   value: 966ac572-f5b7-4bbe-aa88-c76419c0f851
 - name: AZURE_TENANT_BASEURL

--- a/config/medlemskap/prod-fss.yml
+++ b/config/medlemskap/prod-fss.yml
@@ -5,14 +5,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkelmedlemskap
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-medlemskap-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: AZURE_TENANT_ID
   value: 62366534-1ec3-4962-8869-9b5535279d0b
 - name: AZURE_TENANT_BASEURL

--- a/config/nais.yml
+++ b/config/nais.yml
@@ -61,10 +61,12 @@ spec:
         kvPath: {{ item.kvPath }}
     {{/each}}
     {{/if}}
-  {{#if env}}
   env:
-  {{# each env as |item| }}
+  - name: KAFKA_CONSUMER_GROUP_ID
+    value: {{#if kafkaConsumerGroup }}{{ kafkaConsumerGroup }}{{else}}{{team}}-sparkel-{{app}}-v1{{/if}}
+  - name: KAFKA_RAPID_TOPIC
+    value: tbd.rapid.v1
+  {{#if env}}{{# each env as |item| }}
   - name: {{ item.name }}
     value: "{{ item.value }}"
-  {{/each }}
-  {{/if}}
+  {{/each }}{{/if}}

--- a/config/norg/dev-fss.yml
+++ b/config/norg/dev-fss.yml
@@ -9,7 +9,3 @@ env:
   value: https://app-q1.adeo.no/tpsws-aura/ws/Person/v3
 - name: SECURITY_TOKEN_SERVICE_URL
   value: https://sts-q1.preprod.local/SecurityTokenServiceProvider/
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-norg-v1

--- a/config/norg/prod-fss.yml
+++ b/config/norg/prod-fss.yml
@@ -3,17 +3,9 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkelnorg
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
 - name: NORG2_BASE_URL
   value: https://app.adeo.no/norg2/api/v1
 - name: PERSONV3_URL
   value: https://app.adeo.no/tpsws-aura/ws/Person/v3
 - name: SECURITY_TOKEN_SERVICE_URL
   value: https://sts.adeo.no/SecurityTokenServiceProvider/
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-norg-v1

--- a/config/personinfo/dev-fss.yml
+++ b/config/personinfo/dev-fss.yml
@@ -3,10 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/dev/srvsparkelpersoninfo
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-personinfo-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: STS_BASE_URL
   value: http://security-token-service.default.svc.nais.local
 - name: PDL_URL

--- a/config/personinfo/prod-fss.yml
+++ b/config/personinfo/prod-fss.yml
@@ -3,14 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkelpersoninfo
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-personinfo-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: STS_BASE_URL
   value: http://security-token-service.default.svc.nais.local
 - name: PDL_URL

--- a/config/pleiepenger/dev-fss.yml
+++ b/config/pleiepenger/dev-fss.yml
@@ -6,10 +6,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/dev/srvsparkelpleiepenge
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-pleiepenger-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: AZURE_TENANT_ID
   value: 966ac572-f5b7-4bbe-aa88-c76419c0f851
 - name: AZURE_TENANT_BASEURL

--- a/config/pleiepenger/prod-fss.yml
+++ b/config/pleiepenger/prod-fss.yml
@@ -5,14 +5,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkelpleiepenge
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-pleiepenger-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: AZURE_TENANT_ID
   value: 62366534-1ec3-4962-8869-9b5535279d0b
 - name: AZURE_TENANT_BASEURL

--- a/config/sputnik/dev-fss.yml
+++ b/config/sputnik/dev-fss.yml
@@ -3,10 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/dev/srvsputnik
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-sputnik-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: FPSAK_BASE_URL
   value: http://fpsak.teamforeldrepenger.svc.nais.local
 - name: STS_BASE_URL

--- a/config/sputnik/prod-fss.yml
+++ b/config/sputnik/prod-fss.yml
@@ -3,14 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsputnik
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sputnik-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: FPSAK_BASE_URL
   value: http://fpsak.teamforeldrepenger.svc.nais.local
 - name: STS_BASE_URL

--- a/config/sykepengeperioder-mock/dev-fss.yml
+++ b/config/sykepengeperioder-mock/dev-fss.yml
@@ -1,8 +1,1 @@
 kafkaPool: nav-dev
-mountPaths: []
-env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-sykepengeperioder-mock-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
-

--- a/config/sykepengeperioder/dev-fss.yml
+++ b/config/sykepengeperioder/dev-fss.yml
@@ -3,10 +3,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/azure
   kvPath: /azuread/data/dev/creds/sparkel-sykepengeperioder
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-sykepengeperioder-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: AZURE_TENANT_ID
   value: 966ac572-f5b7-4bbe-aa88-c76419c0f851
 - name: AZURE_TENANT_BASEURL

--- a/config/sykepengeperioder/prod-fss.yml
+++ b/config/sykepengeperioder/prod-fss.yml
@@ -7,14 +7,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkelsykepeng
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-sykepengeperioder-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: AZURE_TENANT_ID
   value: 62366534-1ec3-4962-8869-9b5535279d0b
 - name: AZURE_TENANT_BASEURL

--- a/config/vilkarsproving/dev-fss.yml
+++ b/config/vilkarsproving/dev-fss.yml
@@ -5,10 +5,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/dev/srvsparkelvilkar
 env:
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: tbd-sparkel-vilkarsproving-v1
-- name: KAFKA_RAPID_TOPIC
-  value: tbd.rapid.v1
 - name: AZURE_TENANT_ID
   value: 966ac572-f5b7-4bbe-aa88-c76419c0f851
 - name: STS_URL

--- a/config/vilkarsproving/prod-fss.yml
+++ b/config/vilkarsproving/prod-fss.yml
@@ -5,14 +5,6 @@ mountPaths:
 - mountPath: /var/run/secrets/nais.io/service_user
   kvPath: /serviceuser/data/prod/srvsparkelvilkar
 env:
-- name: KAFKA_PREFER_ON_PREM
-  value: "true"
-- name: KAFKA_BOOTSTRAP_SERVERS
-  value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443
-- name: KAFKA_CONSUMER_GROUP_ID
-  value: sparkel-vilkarsproving-v1
-- name: KAFKA_RAPID_TOPIC
-  value: helse-rapid-v1
 - name: AZURE_TENANT_ID
   value: 62366534-1ec3-4962-8869-9b5535279d0b
 - name: STS_URL


### PR DESCRIPTION
- alle consumer groups settes til defaulten `[team]-sparkel-[app]-v1`. Kan overstyres med `kafkaConsumerGroup` i vars-filene
- rapid topic hardkodes i nais.yml