### PR TITLE
Aiven-config i stedet for onprem-config for identer

### DIFF
--- a/config/identer/dev-gcp.yml
+++ b/config/identer/dev-gcp.yml
@@ -5,10 +5,6 @@ replicas:
 env:
   - name: STS_BASE_URL
     value: http://security-token-service.default.svc.nais.local
-  - name: KAFKA_BOOTSTRAP_SERVERS
-    value: SSL://b27apvl00045.preprod.local:8443,SSL://b27apvl00046.preprod.local:8443,SSL://b27apvl00047.preprod.local:8443
-envFrom:
-  - gcp-sparkelidenter-credentials
 gcp:
   type: POSTGRES_14
   name: sparkelidenter

--- a/config/identer/dev-gcp.yml
+++ b/config/identer/dev-gcp.yml
@@ -2,9 +2,6 @@ kafkaPool: nav-dev
 replicas:
   min: "1"
   max: "1"
-env:
-  - name: STS_BASE_URL
-    value: http://security-token-service.default.svc.nais.local
 gcp:
   type: POSTGRES_14
   name: sparkelidenter

--- a/config/identer/prod-gcp.yml
+++ b/config/identer/prod-gcp.yml
@@ -2,9 +2,6 @@ kafkaPool: nav-prod
 replicas:
   min: "0"
   max: "0"
-env:
-  - name: STS_BASE_URL
-    value: http://security-token-service.default.svc.nais.local
 gcp:
   type: POSTGRES_14
   name: sparkelidenter

--- a/config/identer/prod-gcp.yml
+++ b/config/identer/prod-gcp.yml
@@ -5,10 +5,6 @@ replicas:
 env:
   - name: STS_BASE_URL
     value: http://security-token-service.default.svc.nais.local
-  - name: KAFKA_BOOTSTRAP_SERVERS
-    value: SASL_SSL://a01apvl00145.adeo.no:8443,SASL_SSL://a01apvl00146.adeo.no:8443,SASL_SSL://a01apvl00147.adeo.no:8443,SASL_SSL://a01apvl00149.adeo.no:8443,SASL_SSL://a01apvl00150.adeo.no:8443
-envFrom:
-  - gcp-sparkelidenter-credentials
 gcp:
   type: POSTGRES_14
   name: sparkelidenter

--- a/identer/src/main/kotlin/no/nav/helse/sparkel/identer/App.kt
+++ b/identer/src/main/kotlin/no/nav/helse/sparkel/identer/App.kt
@@ -5,7 +5,7 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.sparkel.identer.db.DataSourceBuilder
 import no.nav.helse.sparkel.identer.db.IdentifikatorDao
 
-val PDL_AKTØR_TOPIC = "aapen-person-pdl-aktor-v1"
+const val PDL_AKTØR_TOPIC = "pdl.aktor-v2"
 
 fun main() {
     val app = createApp(System.getenv())

--- a/identer/src/main/kotlin/no/nav/helse/sparkel/identer/KafkaConfig.kt
+++ b/identer/src/main/kotlin/no/nav/helse/sparkel/identer/KafkaConfig.kt
@@ -5,21 +5,17 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.KafkaConsumer
-import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 
 private fun loadBaseConfig(): Properties = Properties().also {
-    val username = System.getenv("sparkelidenter_username")
-    val password = System.getenv("sparkelidenter_password")
-    it["sasl.jaas.config"] = "org.apache.kafka.common.security.plain.PlainLoginModule required " +
-            "username=\"$username\" password=\"$password\";"
-    it["bootstrap.servers"] = System.getenv("KAFKA_BOOTSTRAP_SERVERS")
+    it["bootstrap.servers"] = System.getenv("KAFKA_BROKERS")
     it["specific.avro.reader"] = true
-    it[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] = "SASL_SSL"
-    it[SaslConfigs.SASL_MECHANISM] = "PLAIN"
-    it[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = System.getenv("NAV_TRUSTSTORE_PATH")
-    it[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = System.getenv("NAV_TRUSTSTORE_PASSWORD")
+    it[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] = "SSL"
+    it[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = System.getenv("KAFKA_KEYSTORE_PATH")
+    it[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = System.getenv("KAFKA_CREDSTORE_PASSWORD")
+    it[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = System.getenv("KAFKA_TRUSTSTORE_PATH")
+    it[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = System.getenv("KAFKA_CREDSTORE_PASSWORD")
     // consumer specifics:
     it[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
     it[ConsumerConfig.GROUP_ID_CONFIG] = "sparkel-identer-v1"


### PR DESCRIPTION
~~Før denne kan merges må vi sette offset for `sparkel-identer-v1` på `pdl.aktor-v2` i Aiven tilsvarende offset appen har for `aapen-person-pdl-aktor-v1` on-prem.~~

Det ligger en secret kalt `gcp-sparkelidenter-credentials` i gcp (dev/prod) som inneholder informasjon som ikke lenger er i bruk.

SASL SSL brukes ikke på Aiven, derfor er konfigurasjonen for dette fjernet.